### PR TITLE
Add argument to enable output of .srt file

### DIFF
--- a/auto_subtitle/utils.py
+++ b/auto_subtitle/utils.py
@@ -3,7 +3,9 @@ from typing import Iterator, TextIO
 
 
 def str2bool(string):
-    str2val = {"True": True, "False": False}
+    string = string.lower()
+    str2val = {"true": True, "false": False}
+
     if string in str2val:
         return str2val[string]
     else:


### PR DESCRIPTION
#4 

Awesome tool, found it would be useful to only generate the srt file(s) in some cases, and not overlay the subtitles on the actual video. E.g. when processing a video to be uploaded to a web player with subtitle support. 

Since the .srt is already generated in the process, thought it'd be nice to have it as part of the output as an option 😊

Some minor changes: 
- Enable .srt output *along* with video file 
- Enable .srt only output
- Case insensitive conversion for string to boolean arguments