### PR TITLE
Adding language definition argument

### DIFF
--- a/auto_subtitle/cli.py
+++ b/auto_subtitle/cli.py
@@ -5,6 +5,7 @@ import argparse
 import warnings
 import tempfile
 from .utils import filename, str2bool, write_srt
+from whisper.tokenizer import LANGUAGES, TO_LANGUAGE_CODE
 
 
 def main():
@@ -26,7 +27,7 @@ def main():
     parser.add_argument("--task", type=str, default="transcribe", choices=[
                         "transcribe", "translate"], help="whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate')")
 
-    parser.add_argument("--language", type=str, default=None, choices=sorted(whisper.LANGUAGES.keys()) + sorted([k.title() for k in whisper.TO_LANGUAGE_CODE.keys()]), help="language spoken in the audio, specify None to perform language detection")
+    parser.add_argument("--language", type=str, default=None, choices=sorted(LANGUAGES.keys()) + sorted([k.title() for k in TO_LANGUAGE_CODE.keys()]), help="language spoken in the audio, specify None to perform language detection")
 
     args = parser.parse_args().__dict__
     model_name: str = args.pop("model")

--- a/auto_subtitle/cli.py
+++ b/auto_subtitle/cli.py
@@ -26,6 +26,8 @@ def main():
     parser.add_argument("--task", type=str, default="transcribe", choices=[
                         "transcribe", "translate"], help="whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate')")
 
+    parser.add_argument("--language", type=str, default=None, choices=sorted(whisper.LANGUAGES.keys()) + sorted([k.title() for k in whisper.TO_LANGUAGE_CODE.keys()]), help="language spoken in the audio, specify None to perform language detection")
+
     args = parser.parse_args().__dict__
     model_name: str = args.pop("model")
     output_dir: str = args.pop("output_dir")


### PR DESCRIPTION
I have seen that the auto-detection of languages does not work very well for some of the more obscure languages.

This PR adds a language argument so that the input language can be set directly at the command line.