### PR TITLE
Update `Whisper` package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author="Miguel Piedrafita",
     install_requires=[
         'youtube-dl',
-        'whisper @ git+https://github.com/openai/whisper.git@main#egg=whisper'
+        'openai-whisper @ git+https://github.com/openai/whisper.git@main#egg=whisper'
     ],
     description="Automatically generate and embed subtitles into your videos",
     entry_points={


### PR DESCRIPTION
This PR changes the package requirement from `whisper` to `openai-whisper`.

This should solve this issue which occurs during installation.
```
ERROR: Could not find a version that satisfies the requirement whisper (unavailable) (from auto-subtitle)
ERROR: No matching distribution found for whisper (unavailable)
```