### PR TITLE
Fix audio out of sync

### DIFF
--- a/auto_subtitle/cli.py
+++ b/auto_subtitle/cli.py
@@ -4,6 +4,7 @@ import whisper
 import argparse
 import warnings
 import tempfile
+import subprocess
 from .utils import filename, str2bool, write_srt
 
 
@@ -71,10 +72,9 @@ def get_audio(paths):
         print(f"Extracting audio from {filename(path)}...")
         output_path = os.path.join(temp_dir, f"{filename(path)}.wav")
 
-        ffmpeg.input(path).output(
-            output_path,
-            acodec="pcm_s16le", ac=1, ar="16k"
-        ).run(quiet=True, overwrite_output=True)
+        # Use subprocess instead of the ffmpeg module due to conflicting argument name "async"
+        if subprocess.run(['ffmpeg', '-y', '-i', path, '-acodec', 'pcm_s16le', '-ac', '1', '-async', '1', output_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode > 0:
+            raise Exception(f'Error occurred while extracting audio from {filename(path)}')
 
         audio_paths[path] = output_path
 


### PR DESCRIPTION
I encountered a similar issue described in #28, but my videos are in English. I suspect it is related to the variable framerates of the video's recording device.

After some debugging, it turns out the output `.wav` audio file is out of sync with the original video. Thus, I added the `-async 1` option to `ffmpeg` and it fixed the issue. 

Also, because`async` is a reversed keyword in Python, I replaced the call to `ffmpeg` with `subprocess.run`.