### PR TITLE
Add --word_timestamps flag for better syncing

### DIFF
--- a/auto_subtitle/cli.py
+++ b/auto_subtitle/cli.py
@@ -28,6 +28,8 @@ def main():
     parser.add_argument("--language", type=str, default="auto", choices=["auto","af","am","ar","as","az","ba","be","bg","bn","bo","br","bs","ca","cs","cy","da","de","el","en","es","et","eu","fa","fi","fo","fr","gl","gu","ha","haw","he","hi","hr","ht","hu","hy","id","is","it","ja","jw","ka","kk","km","kn","ko","la","lb","ln","lo","lt","lv","mg","mi","mk","ml","mn","mr","ms","mt","my","ne","nl","nn","no","oc","pa","pl","ps","pt","ro","ru","sa","sd","si","sk","sl","sn","so","sq","sr","su","sv","sw","ta","te","tg","th","tk","tl","tr","tt","uk","ur","uz","vi","yi","yo","zh"], 
     help="What is the origin language of the video? If unset, it is detected automatically.")
 
+    parser.add_argument("--word_timestamps", type=str2bool, default=False, help="(experimental) extract word-level timestamps and refine the results based on them")
+
     args = parser.parse_args().__dict__
     model_name: str = args.pop("model")
     output_dir: str = args.pop("output_dir")


### PR DESCRIPTION
Based on this discussion: https://github.com/openai/whisper/discussions/1888

Sync accuracy is greatly improved by setting the `--word_timestamps True`.

Usage:

```sh
auto_subtitle video.mkv --word_timestamps True
```

Possible fix for #28 and #37