### PR TITLE
No condition on text & load models from external directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 *.egg-info
 auto_subtitle/__pycache__
 build
+.vscode/

--- a/auto_subtitle/.vscode/settings.json
+++ b/auto_subtitle/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda",
+    "python-envs.pythonProjects": []
+}

--- a/auto_subtitle/.vscode/settings.json
+++ b/auto_subtitle/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "python-envs.defaultEnvManager": "ms-python.python:conda",
-    "python-envs.defaultPackageManager": "ms-python.python:conda",
-    "python-envs.pythonProjects": []
-}

--- a/auto_subtitle/cli.py
+++ b/auto_subtitle/cli.py
@@ -14,12 +14,16 @@ def main():
                         help="paths to video files to transcribe")
     parser.add_argument("--model", default="small",
                         choices=whisper.available_models(), help="name of the Whisper model to use")
+    parser.add_argument("--model_weights_root", type=str, default=None,
+                        help="path to the root directory of the model weights")
     parser.add_argument("--output_dir", "-o", type=str,
                         default=".", help="directory to save the outputs")
     parser.add_argument("--output_srt", type=str2bool, default=False,
                         help="whether to output the .srt file along with the video files")
     parser.add_argument("--srt_only", type=str2bool, default=False,
                         help="only generate the .srt file and not create overlayed video")
+    parser.add_argument("--condition_on_previous_text", type=str2bool, default=False,
+                        help="whether to condition the model on the previous text")
     parser.add_argument("--verbose", type=str2bool, default=False,
                         help="whether to print out the progress and debug messages")
 
@@ -34,6 +38,8 @@ def main():
     output_srt: bool = args.pop("output_srt")
     srt_only: bool = args.pop("srt_only")
     language: str = args.pop("language")
+    condition_on_previous_text: bool = args.pop("condition_on_previous_text")
+    
     
     os.makedirs(output_dir, exist_ok=True)
 
@@ -45,10 +51,11 @@ def main():
     elif language != "auto":
         args["language"] = language
         
-    model = whisper.load_model(model_name)
+    model_weights_root = args.pop("model_weights_root")
+    model = whisper.load_model(model_name, download_root=model_weights_root)
     audios = get_audio(args.pop("video"))
     subtitles = get_subtitles(
-        audios, output_srt or srt_only, output_dir, lambda audio_path: model.transcribe(audio_path, **args)
+        audios, output_srt or srt_only, output_dir, lambda audio_path: model.transcribe(audio_path, condition_on_previous_text=condition_on_previous_text, **args)
     )
 
     if srt_only:


### PR DESCRIPTION
I made two minor changes:

1. Added an option for `condition_on_previous_text` with the default value set to `False`. I noticed that Whisper often gets confused when conditioned on previous text, especially during scenes with unusual background sounds (e.g., crowd noise, overlapping speech, etc.), particularly when the language is not English. In these cases, even a quick moment of a confusing sound can generate nonsense that ruins the next 30 seconds.

2. Added `model_weights_root` to avoid re-downloading the large checkpoints. I already have them stored elsewhere, so this is convenient for my setup and people like me.